### PR TITLE
feat: expand history with roulette details and purchases

### DIFF
--- a/src/main/java/com/buseiny/app/controller/ApiController.java
+++ b/src/main/java/com/buseiny/app/controller/ApiController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.List;
+import com.buseiny.app.model.Purchase;
 
 @RestController
 @RequestMapping("/api")
@@ -21,7 +23,7 @@ public class ApiController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<?> me() throws IOException {
+    public ResponseEntity<Map<String, Object>> me() throws IOException {
         Map<String,Object> status = state.status();
         return ResponseEntity.ok(status);
     }
@@ -84,5 +86,10 @@ public class ApiController {
         boolean ok = state.purchase(id);
         if (!ok) return ResponseEntity.badRequest().body("not enough balance or not found");
         return ResponseEntity.ok(state.status());
+    }
+
+    @GetMapping("/purchases")
+    public ResponseEntity<List<Purchase>> purchases() throws IOException {
+        return ResponseEntity.ok(state.getPurchases());
     }
 }

--- a/src/main/java/com/buseiny/app/model/UserState.java
+++ b/src/main/java/com/buseiny/app/model/UserState.java
@@ -3,6 +3,7 @@ package com.buseiny.app.model;
 import java.util.*;
 
 import lombok.Data;
+import com.buseiny.app.dto.HistoryDTO;
 
 @Data
 public class UserState {
@@ -22,6 +23,9 @@ public class UserState {
     private Map<String, Integer> genericStreaks = new HashMap<>();
     // records of generic tasks per date: yyyy-MM-dd -> set of ids
     private Map<String, Set<String>> genericDoneByDay = new HashMap<>();
+
+    // extra history entries like roulette bonuses
+    private Map<String, List<HistoryDTO.Item>> historyExtras = new HashMap<>();
 
     // purchases and achievements
     private List<com.buseiny.app.model.Purchase> purchases = new ArrayList<>();

--- a/src/main/java/com/buseiny/app/service/RouletteService.java
+++ b/src/main/java/com/buseiny/app/service/RouletteService.java
@@ -84,12 +84,14 @@ public class RouletteService {
                     rs.setEffect(RouletteEffect.BONUS_POINTS);
                     rs.setBonusPoints(1 + ThreadLocalRandom.current().nextInt(5));
                     state.addBalance(rs.getBonusPoints());
+                    state.addHistory(LocalDate.now(state.zone()), "Рулетка бонус", rs.getBonusPoints());
                 }
             }
             case BONUS_POINTS -> {
                 int pts = 1 + ThreadLocalRandom.current().nextInt(5);
                 rs.setBonusPoints(pts);
                 state.addBalance(pts);
+                state.addHistory(LocalDate.now(state.zone()), "Рулетка бонус", pts);
             }
             case SHOP_DISCOUNT_50 -> {
                 var items = state.getState().getShop();

--- a/src/main/java/com/buseiny/app/service/StateService.java
+++ b/src/main/java/com/buseiny/app/service/StateService.java
@@ -175,7 +175,9 @@ public class StateService {
                 && !rs.isDailyPenaltyApplied()) {
             var dailyDone = isDailyDone(rs.getDate(), rs.getDailyId());
             if (!dailyDone) {
-                addBalance(-Math.abs(rs.getDailyBaseReward()));
+                int pen = -Math.abs(rs.getDailyBaseReward());
+                addBalance(pen);
+                addHistory(today, "Штраф за пропуск: " + prettyDaily(rs.getDailyId()), pen);
             }
             rs.setDailyPenaltyApplied(true);
             save();
@@ -210,6 +212,9 @@ public class StateService {
     void addDailyWithRouletteBonus(String dailyId, int base){
         int mult = isRouletteDailyToday(dailyId) ? 2 : 1;
         addBalance(base * mult);
+        if (mult == 2) {
+            addHistory(LocalDate.now(zone()), "Рулетка бонус: " + prettyDaily(dailyId), base);
+        }
     }
 
     private boolean isRouletteDailyToday(String dailyId){
@@ -228,6 +233,33 @@ public class StateService {
         if (itemId.equals(rs.getFreeShopId())) return 0;
         if (itemId.equals(rs.getDiscountedShopId())) return Math.max(0, baseCost / 2);
         return baseCost;
+    }
+
+    void addHistory(LocalDate date, String label, int points){
+        var extras = state.getAnna().getHistoryExtras();
+        extras.computeIfAbsent(date.toString(), k -> new ArrayList<>())
+                .add(new HistoryDTO.Item(label, points));
+    }
+
+    private String prettyDaily(String id){
+        if (id == null) return "";
+        return switch (id) {
+            case "nutrition" -> "Нутрициология";
+            case "english" -> "Английский";
+            case "sport" -> "Спорт";
+            case "yoga" -> "Йога";
+            case "viet" -> "Вьетнамские слова";
+            default -> {
+                if (id.startsWith("g:")) {
+                    var gid = id.substring(2);
+                    var opt = state.getGenericDaily().stream()
+                            .filter(g -> g.id().equals(gid))
+                            .findFirst();
+                    yield opt.map(GenericDailyTaskDef::title).orElse(gid);
+                }
+                yield id;
+            }
+        };
     }
 
     // --- Public API used by controllers ---
@@ -302,6 +334,7 @@ public class StateService {
                             && rs.getEffect() == RouletteEffect.GOAL_X2
                             && g.id().equals(rs.getGoalId())) {
                         reward *= 2;
+                        addHistory(LocalDate.now(zone()), "Рулетка бонус: цель x2 " + g.title(), g.reward());
                     }
                     addBalance(reward);
                     save();
@@ -322,9 +355,17 @@ public class StateService {
         int cost = effectiveCostToday(item.id(), item.cost());
         if (u.getBalance() < cost) return false;
         u.setBalance(u.getBalance() - cost);
-        u.getPurchases().add(new Purchase(item.id(), item.title(), cost, LocalDateTime.now(zone())));
+        var when = LocalDateTime.now(zone());
+        u.getPurchases().add(new Purchase(item.id(), item.title(), cost, when));
         save();
         return true;
+    }
+
+    public synchronized List<Purchase> getPurchases() throws IOException {
+        processDayBoundariesIfNeeded();
+        var list = new ArrayList<>(state.getAnna().getPurchases());
+        list.sort(Comparator.comparing(Purchase::purchasedAt).reversed());
+        return list;
     }
 
     // --- Admin ---
@@ -467,6 +508,26 @@ public class StateService {
             }
         }
 
+        // Weekly nutrition result applied on this day
+        if (date.getDayOfWeek() == DayOfWeek.MONDAY) {
+            LocalDate prevWeekStart = date.minusWeeks(1);
+            if (!prevWeekStart.isBefore(firstFullWeekStart())) {
+                int minutes = sumNutritionMinutesForWeek(prevWeekStart);
+                if (minutes >= 1080) items.add(new HistoryDTO.Item("Недельный бонус", 14));
+                else items.add(new HistoryDTO.Item("Недельный штраф", -20));
+            }
+        }
+
+        // Purchases on this day
+        for (var p : u.getPurchases()) {
+            if (p.purchasedAt() != null && p.purchasedAt().toLocalDate().equals(date)) {
+                items.add(new HistoryDTO.Item("Покупка: " + p.titleSnapshot(), -p.costSnapshot()));
+            }
+        }
+
+        // Extra entries (roulette bonuses etc.)
+        items.addAll(u.getHistoryExtras().getOrDefault(dateStr, List.of()));
+
         int total = items.stream().mapToInt(HistoryDTO.Item::points).sum();
         return new HistoryDTO.DayHistory(dateStr, total, items);
     }
@@ -570,6 +631,7 @@ public class StateService {
         for (var p : u.getPurchases()) {
             if (p.purchasedAt() != null) dates.add(p.purchasedAt().toLocalDate());
         }
+        for (var k : u.getHistoryExtras().keySet()) dates.add(java.time.LocalDate.parse(k));
         if (dates.isEmpty()) { save(); return; }
 
         // Threshold for weekly calculation
@@ -641,6 +703,11 @@ public class StateService {
                 if (p.purchasedAt() != null && p.purchasedAt().toLocalDate().equals(d)) {
                     u.setBalance(Math.max(0, u.getBalance() - p.costSnapshot()));
                 }
+            }
+
+            // Extra roulette-related history entries
+            for (var extra : u.getHistoryExtras().getOrDefault(key, Collections.emptyList())) {
+                addBalance(extra.points());
             }
 
             // Apply weekly +14/-20 at the start of each new week (Monday)

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -19,6 +19,7 @@
       <div class="text-xs opacity-75">До конца недели: <span id="weekTimer"></span></div>
       <button class="btn" onclick="openWheel()">Рулетка 🎡</button>
       <button class="btn" onclick="openHistory()">История</button>
+      <button class="btn" onclick="openPurchases()">Покупки</button>
     </div>
 
   </header>
@@ -416,21 +417,46 @@
       wrap.innerHTML = `<div class="text-sm opacity-70">Ничего не заработано в этот день.</div>`;
     } else {
       d.items.forEach(it => {
+        const sign = it.points > 0 ? '+' : '';
         wrap.insertAdjacentHTML('beforeend', `
           <div class="p-2 rounded-lg bg-slate-800/60 border border-slate-700/50 flex justify-between">
             <div class="text-sm">${it.label}</div>
-            <div class="text-sm font-semibold">+${it.points}</div>
+            <div class="text-sm font-semibold">${sign}${it.points}</div>
           </div>
         `);
       });
       wrap.insertAdjacentHTML('beforeend', `
         <div class="mt-2 p-2 rounded-lg bg-slate-900/60 border border-slate-700/50 flex justify-between">
           <div class="text-sm font-semibold">Итого</div>
-          <div class="text-sm font-semibold">+${d.total}</div>
+          <div class="text-sm font-semibold">${d.total >= 0 ? '+' : ''}${d.total}</div>
         </div>
       `);
     }
     $('#histDayPanel').classList.remove('hidden');
+  }
+
+  async function openPurchases(){
+    const data = await api('/api/purchases');
+    const wrap = $('#purchList'); wrap.innerHTML = '';
+    if (!data || data.length === 0){
+      wrap.innerHTML = `<div class="text-sm opacity-70">Покупок пока нет.</div>`;
+    } else {
+      data.forEach(p => {
+        const dt = new Date(p.purchasedAt).toLocaleDateString('ru-RU', {day:'2-digit', month:'long', year:'numeric'});
+        wrap.insertAdjacentHTML('beforeend', `
+          <div class="p-2 rounded-lg bg-slate-800/60 border border-slate-700/50 flex justify-between">
+            <div class="text-sm">${p.titleSnapshot} <span class="opacity-60 text-xs">${dt}</span></div>
+            <div class="text-sm font-semibold">-${p.costSnapshot}</div>
+          </div>
+        `);
+      });
+    }
+    $('#purchModal').classList.remove('hidden');
+    $('#purchModal').classList.add('flex');
+  }
+  function closePurchases(){
+    $('#purchModal').classList.add('hidden');
+    $('#purchModal').classList.remove('flex');
   }
 
   function openWheel(){
@@ -533,6 +559,17 @@
       <div class="text-sm font-semibold mb-2">Детали: <span id="histDayLabel"></span></div>
       <div id="histDayList" class="space-y-1"></div>
     </div>
+  </div>
+</div>
+
+<!-- Покупки: модальное окно -->
+<div id="purchModal" class="fixed inset-0 bg-black/60 hidden items-center justify-center z-50">
+  <div class="bg-slate-900 w-full max-w-md rounded-2xl shadow-xl p-4">
+    <div class="flex items-center justify-between mb-2">
+      <div class="text-lg font-semibold">Покупки</div>
+      <button class="btn" onclick="closePurchases()">Закрыть</button>
+    </div>
+    <div id="purchList" class="space-y-1 max-h-[60vh] overflow-y-auto"></div>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- track roulette bonuses, penalties and purchases in daily history
- expose purchases via `/api/purchases` and add UI to view them
- show negative values and weekly results in day history

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b28644a4288327abeb9d15ac000cec