### PR TITLE
Add scheduled maintenance to reset missed streaks

### DIFF
--- a/src/main/java/com/buseiny/app/BuseinyApp.java
+++ b/src/main/java/com/buseiny/app/BuseinyApp.java
@@ -2,8 +2,10 @@ package com.buseiny.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BuseinyApp {
     public static void main(String[] args) {
         SpringApplication.run(BuseinyApp.class, args);

--- a/src/main/java/com/buseiny/app/service/DailyScheduler.java
+++ b/src/main/java/com/buseiny/app/service/DailyScheduler.java
@@ -1,0 +1,29 @@
+package com.buseiny.app.service;
+
+import java.io.IOException;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodic maintenance tasks like streak resets and roulette penalties.
+ */
+@Component
+@Slf4j
+public class DailyScheduler {
+    private final StateService state;
+
+    public DailyScheduler(StateService state) {
+        this.state = state;
+    }
+
+    @Scheduled(cron = "0 5 0 * * *", zone = "${app.timezone}")
+    public void dailyMaintenance() {
+        try {
+            state.resetStreaksIfMissedYesterday();
+        } catch (IOException e) {
+            log.error("Failed to run daily maintenance", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable Spring scheduling
- implement streak reset logic for missed days
- schedule daily maintenance task to reset streaks

## Testing
- `mvn -q -ntp test` *(fails: 'dependencies.dependency.version' missing, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b45af866888327a291e861c0f4f627