### PR TITLE
feat: weekly daily task penalties and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All data is stored in `data/app-state.json` (path configured in `application.yml
 ## Features
 - Daily tasks (minute-based and checkboxes)
 - Streaks for sport, English and Vietnamese words
-- Weekly nutrition goal: 16 hours (960 minutes) gives +14, otherwise −20, applied after the first full week
+- Weekly nutrition goal: 14 hours (900 minutes) gives +14, otherwise −20, applied after the first full week
 - Shop for spending Buseiny points
 - One-time goals (achievements)
 - Weekly progress and countdown

--- a/data/app-state.json
+++ b/data/app-state.json
@@ -3,7 +3,7 @@
   "lastProcessedWeekStart" : "2025-09-08",
   "anna" : {
     "username" : "Анечка",
-    "balance" : 94,
+    "balance" : 125,
     "avatarUrl" : "/assets/avatar.png",
     "daily" : {
       "2025-08-27" : {
@@ -115,11 +115,65 @@
         "vietWordsAwarded" : false
       },
       "2025-09-08" : {
-        "nutritionMinutes" : 45,
+        "nutritionMinutes" : 105,
         "englishMinutes" : 0,
         "nutritionDailyAwarded" : false,
         "englishDailyAwarded" : false,
         "sportAwarded" : false,
+        "yogaAwarded" : false,
+        "vietWordsAwarded" : false
+      },
+      "2025-09-09" : {
+        "nutritionMinutes" : 105,
+        "englishMinutes" : 0,
+        "nutritionDailyAwarded" : false,
+        "englishDailyAwarded" : false,
+        "sportAwarded" : false,
+        "yogaAwarded" : false,
+        "vietWordsAwarded" : false
+      },
+      "2025-09-10" : {
+        "nutritionMinutes" : 75,
+        "englishMinutes" : 60,
+        "nutritionDailyAwarded" : false,
+        "englishDailyAwarded" : true,
+        "sportAwarded" : false,
+        "yogaAwarded" : false,
+        "vietWordsAwarded" : false
+      },
+      "2025-09-11" : {
+        "nutritionMinutes" : 120,
+        "englishMinutes" : 0,
+        "nutritionDailyAwarded" : false,
+        "englishDailyAwarded" : false,
+        "sportAwarded" : false,
+        "yogaAwarded" : false,
+        "vietWordsAwarded" : false
+      },
+      "2025-09-12" : {
+        "nutritionMinutes" : 105,
+        "englishMinutes" : 0,
+        "nutritionDailyAwarded" : false,
+        "englishDailyAwarded" : false,
+        "sportAwarded" : false,
+        "yogaAwarded" : false,
+        "vietWordsAwarded" : false
+      },
+      "2025-09-13" : {
+        "nutritionMinutes" : 90,
+        "englishMinutes" : 0,
+        "nutritionDailyAwarded" : false,
+        "englishDailyAwarded" : false,
+        "sportAwarded" : false,
+        "yogaAwarded" : false,
+        "vietWordsAwarded" : false
+      },
+      "2025-09-14" : {
+        "nutritionMinutes" : 30,
+        "englishMinutes" : 0,
+        "nutritionDailyAwarded" : false,
+        "englishDailyAwarded" : false,
+        "sportAwarded" : true,
         "yogaAwarded" : false,
         "vietWordsAwarded" : false
       }
@@ -128,8 +182,8 @@
     "englishStreak" : 0,
     "vietWordsStreak" : 0,
     "genericStreaks" : {
-      "sleep-before-23" : 12,
-      "wake-at-8" : 0
+      "wake-at-8" : 0,
+      "sleep-before-23" : 18
     },
     "genericDoneByDay" : {
       "2025-08-27" : [ "sleep-before-23" ],
@@ -143,7 +197,14 @@
       "2025-09-04" : [ "wake-at-8", "sleep-before-23" ],
       "2025-09-05" : [ "sleep-before-23" ],
       "2025-09-06" : [ "sleep-before-23" ],
-      "2025-09-07" : [ "sleep-before-23" ]
+      "2025-09-07" : [ "sleep-before-23" ],
+      "2025-09-08" : [ "sleep-before-23" ],
+      "2025-09-09" : [ "sleep-before-23" ],
+      "2025-09-10" : [ "sleep-before-23" ],
+      "2025-09-11" : [ "wake-at-8", "sleep-before-23" ],
+      "2025-09-12" : [ "sleep-before-23" ],
+      "2025-09-13" : [ "sleep-before-23" ],
+      "2025-09-14" : [ "wake-at-8" ]
     },
     "historyExtras" : {
       "2025-09-01" : [ {
@@ -165,6 +226,10 @@
       "2025-09-07" : [ {
         "label" : "Рулетка бонус: Йога",
         "points" : 1
+      } ],
+      "2025-09-10" : [ {
+        "label" : "Рулетка бонус: Английский",
+        "points" : 1
       } ]
     },
     "purchases" : [ {
@@ -175,14 +240,14 @@
     } ],
     "gifts" : [ ],
     "todayRoulette" : {
-      "date" : "2025-09-08",
-      "effect" : "GOAL_X2",
+      "date" : "2025-09-14",
+      "effect" : "SHOP_DISCOUNT_50",
       "dailyId" : null,
       "dailyBaseReward" : null,
       "dailyPenaltyApplied" : false,
-      "goalId" : "yoga-class",
+      "goalId" : null,
       "bonusPoints" : null,
-      "discountedShopId" : null,
+      "discountedShopId" : "no-gadgets",
       "freeShopId" : null
     }
   },
@@ -266,16 +331,19 @@
     "id" : "sleep-before-23",
     "title" : "Лечь спать до 23:00",
     "dailyReward" : 1,
-    "streakEnabled" : true
+    "streakEnabled" : true,
+    "weeklyMin" : 1
   }, {
     "id" : "wake-at-8",
     "title" : "Проснуться в 8:00",
     "dailyReward" : 1,
-    "streakEnabled" : true
+    "streakEnabled" : true,
+    "weeklyMin" : 1
   }, {
     "id" : "minet",
     "title" : "Горловой минет 15 минут",
     "dailyReward" : 2,
-    "streakEnabled" : false
+    "streakEnabled" : false,
+    "weeklyMin" : 1
   } ]
 }

--- a/src/main/java/com/buseiny/app/dto/StatusDTO.java
+++ b/src/main/java/com/buseiny/app/dto/StatusDTO.java
@@ -3,9 +3,9 @@ package com.buseiny.app.dto;
 import com.buseiny.app.model.GenericDailyTaskDef;
 import com.buseiny.app.model.OneTimeGoal;
 import com.buseiny.app.model.ShopItem;
-
 import java.util.List;
 import java.util.Map;
+import com.buseiny.app.dto.WeeklyTaskDTO;
 
 /**
  * Snapshot of the current user status returned by API.
@@ -40,5 +40,6 @@ public record StatusDTO(
         List<GenericDailyTaskDef> genericDaily,
 
         Map<String, Boolean> todayGenericDone,
-        Map<String, Integer> genericStreaks
+        Map<String, Integer> genericStreaks,
+        List<WeeklyTaskDTO> weekDaily
 ) {}

--- a/src/main/java/com/buseiny/app/dto/WeeklyTaskDTO.java
+++ b/src/main/java/com/buseiny/app/dto/WeeklyTaskDTO.java
@@ -1,0 +1,12 @@
+package com.buseiny.app.dto;
+
+/**
+ * Weekly requirement progress for a daily task.
+ */
+public record WeeklyTaskDTO(
+        String id,
+        String title,
+        int required,
+        int done
+) {}
+

--- a/src/main/java/com/buseiny/app/model/GenericDailyTaskDef.java
+++ b/src/main/java/com/buseiny/app/model/GenericDailyTaskDef.java
@@ -1,5 +1,8 @@
 package com.buseiny.app.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * Admin-defined checkbox daily task with optional streak bonus.
  */
@@ -7,5 +10,19 @@ public record GenericDailyTaskDef(
         String id,
         String title,
         int dailyReward,
-        boolean streakEnabled
-) {}
+        boolean streakEnabled,
+        int weeklyMin
+) {
+    @JsonCreator
+    public static GenericDailyTaskDef create(
+            @JsonProperty("id") String id,
+            @JsonProperty("title") String title,
+            @JsonProperty("dailyReward") int dailyReward,
+            @JsonProperty("streakEnabled") boolean streakEnabled,
+            @JsonProperty("weeklyMin") Integer weeklyMin
+    ) {
+        return new GenericDailyTaskDef(id, title, dailyReward, streakEnabled,
+                weeklyMin == null || weeklyMin <= 0 ? 1 : weeklyMin);
+    }
+}
+

--- a/src/main/java/com/buseiny/app/service/HistoryService.java
+++ b/src/main/java/com/buseiny/app/service/HistoryService.java
@@ -137,7 +137,7 @@ public class HistoryService {
             LocalDate prevWeekStart = date.minusWeeks(1);
             if (!prevWeekStart.isBefore(state.firstFullWeekStart())) {
                 int minutes = state.sumNutritionMinutesForWeek(prevWeekStart);
-                if (minutes >= 960) items.add(new HistoryDTO.Item("Недельный бонус", 14));
+                if (minutes >= 900) items.add(new HistoryDTO.Item("Недельный бонус", 14));
                 else items.add(new HistoryDTO.Item("Недельный штраф", -20));
             }
         }
@@ -296,7 +296,7 @@ public class HistoryService {
                 LocalDate weekStart = TimeUtil.weekStartMonday(d);
                 if (!weekStart.isBefore(firstFullWeekStart)) {
                     int minutes = state.sumNutritionMinutesForWeek(weekStart);
-                    if (minutes >= 960) state.addBalance(14);
+                    if (minutes >= 900) state.addBalance(14);
                     else state.addBalance(-20);
                 }
             }

--- a/src/main/java/com/buseiny/app/service/StateService.java
+++ b/src/main/java/com/buseiny/app/service/StateService.java
@@ -140,7 +140,7 @@ public class StateService {
             LocalDate weekStart = lastProcessed;
             if (!weekStart.isBefore(firstFullWeekStart())){
                 int minutes = sumNutritionMinutesForWeek(weekStart);
-                if (minutes >= 960){ // 16*60
+                if (minutes >= 900){ // 16*60
                     addBalance(14);
                 } else {
                     addBalance(-20);
@@ -294,7 +294,7 @@ public class StateService {
         map.put("vietStreak", u.getVietWordsStreak());
         map.put("englishStreak", u.getEnglishStreak());
         map.put("weekNutritionMinutes", weekMinutes);
-        map.put("weekGoalMinutes", 960);
+        map.put("weekGoalMinutes", 900);
         map.put("secondsUntilWeekEndEpoch", weekEndInstant.getEpochSecond());
         map.put("currentWeekStart", weekStart.toString());
         map.put("goals", getState().getGoals());

--- a/src/main/java/com/buseiny/app/service/StateService.java
+++ b/src/main/java/com/buseiny/app/service/StateService.java
@@ -4,6 +4,7 @@ import com.buseiny.app.dto.HistoryDTO;
 import com.buseiny.app.model.*;
 import com.buseiny.app.repository.StateRepository;
 import com.buseiny.app.util.TimeUtil;
+import com.buseiny.app.dto.WeeklyTaskDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -53,6 +54,72 @@ public class StateService {
         return sum;
     }
 
+    private int countDailyForWeek(LocalDate weekStart, String dailyId){
+        LocalDate d = weekStart;
+        int cnt = 0;
+        for (int i=0;i<7;i++){
+            if (isDailyDone(d, dailyId)) cnt++;
+            d = d.plusDays(1);
+        }
+        return cnt;
+    }
+
+    private int weeklyRequirement(String dailyId){
+        return switch (dailyId){
+            case "nutrition", "english", "sport", "yoga", "viet" -> 1;
+            default -> {
+                if (dailyId.startsWith("g:")) {
+                    var gid = dailyId.substring(2);
+                    var opt = getState().getGenericDaily().stream()
+                            .filter(g -> g.id().equals(gid))
+                            .findFirst();
+                    yield opt.map(d -> d.weeklyMin() <= 0 ? 1 : d.weeklyMin()).orElse(1);
+                }
+                yield 1;
+            }
+        };
+    }
+
+    private int dailyRewardById(String dailyId){
+        return switch (dailyId){
+            case "nutrition" -> 2;
+            case "english" -> 1;
+            case "sport" -> 1;
+            case "yoga" -> 1;
+            case "viet" -> 1;
+            default -> {
+                if (dailyId.startsWith("g:")) {
+                    var gid = dailyId.substring(2);
+                    var opt = getState().getGenericDaily().stream()
+                            .filter(g -> g.id().equals(gid))
+                            .findFirst();
+                    yield opt.map(GenericDailyTaskDef::dailyReward).orElse(0);
+                }
+                yield 0;
+            }
+        };
+    }
+
+    private void applyWeeklyPenalties(LocalDate weekStart){
+        var today = LocalDate.now(zone());
+        List<String> ids = new ArrayList<>(List.of("nutrition","english","sport","yoga","viet"));
+        for (var def : getState().getGenericDaily()){
+            ids.add("g:" + def.id());
+        }
+        for (var id : ids){
+            int done = countDailyForWeek(weekStart, id);
+            int req = weeklyRequirement(id);
+            if (done < req){
+                int miss = req - done;
+                int pen = -5 * Math.abs(dailyRewardById(id)) * miss;
+                if (pen != 0){
+                    addBalance(pen);
+                    addHistory(today, "Штраф за неделю: " + prettyDaily(id), pen);
+                }
+            }
+        }
+    }
+
     LocalDate firstFullWeekStart(){
         var installed = getState().getInstalledAt().toLocalDate();
         return TimeUtil.firstMondayAfter(installed);
@@ -78,6 +145,7 @@ public class StateService {
                 } else {
                     addBalance(-20);
                 }
+                applyWeeklyPenalties(weekStart);
             }
             lastProcessed = lastProcessed.plusWeeks(1);
         }
@@ -234,6 +302,15 @@ public class StateService {
         map.put("genericDaily", getState().getGenericDaily());
         map.put("todayGenericDone", todayGenericDone);
         map.put("genericStreaks", genericStreaks);
+        List<WeeklyTaskDTO> weekly = new ArrayList<>();
+        List.of("nutrition","english","sport","yoga","viet").forEach(id -> {
+            weekly.add(new WeeklyTaskDTO(id, prettyDaily(id), weeklyRequirement(id), countDailyForWeek(weekStart, id)));
+        });
+        for (var def : getState().getGenericDaily()){
+            String gid = "g:" + def.id();
+            weekly.add(new WeeklyTaskDTO(def.id(), def.title(), weeklyRequirement(gid), countDailyForWeek(weekStart, gid)));
+        }
+        map.put("weekDaily", weekly);
         map.put("gifts", u.getGifts());
         return map;
     }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -101,13 +101,13 @@
     <div class="space-y-4">
       <div class="bg-slate-900/70 p-4 rounded-2xl shadow">
         <h2 class="font-semibold mb-2">Недельное обязательное</h2>
-        <div class="text-sm opacity-90">Нутрициология 16 часов/неделю</div>
+        <div class="text-sm opacity-90">Нутрициология 14 часов/неделю</div>
         <div class="w-full bg-slate-800 rounded-full h-3 my-2">
           <div id="weekBar" class="bg-pink-500 h-3 rounded-full" style="width:0%"></div>
         </div>
-        <div class="text-xs opacity-80">Собрано: <span id="weekMin">0</span>/960 минут</div>
+        <div class="text-xs opacity-80">Собрано: <span id="weekMin">0</span>/900 минут</div>
         <p class="text-xs mt-2 opacity-60">
-          По итогам недели: &ge;960 мин → +14, иначе −20. Штраф/награда срабатывают автоматически при переходе недели.
+          По итогам недели: &ge;900 мин → +14, иначе −20. Штраф/награда срабатывают автоматически при переходе недели.
         </p>
         <div id="weekDailyList" class="mt-3 space-y-1 text-sm"></div>
       </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -109,6 +109,7 @@
         <p class="text-xs mt-2 opacity-60">
           По итогам недели: &ge;960 мин → +14, иначе −20. Штраф/награда срабатывают автоматически при переходе недели.
         </p>
+        <div id="weekDailyList" class="mt-3 space-y-1 text-sm"></div>
       </div>
 
       <div class="bg-slate-900/70 p-4 rounded-2xl shadow">
@@ -237,6 +238,18 @@
 
     const pct = Math.min(100, Math.round(100*data.weekNutritionMinutes / data.weekGoalMinutes));
     $('#weekBar').style.width = pct + '%';
+    const wl = $('#weekDailyList'); wl.innerHTML='';
+    (data.weekDaily || []).forEach(t => {
+      const left = t.required - t.done;
+      const done = left <= 0;
+      const status = done ? 'Готово' : `Осталось: ${left}`;
+      wl.insertAdjacentHTML('beforeend', `
+        <div class="flex justify-between ${done?'opacity-60':''}">
+          <div>${t.title}</div>
+          <div>${status}${done?' ✔':''}</div>
+        </div>
+      `);
+    });
 
     $('#nutriBadge').innerHTML = data.todayNutritionAwarded
             ? '<span class="pill bg-emerald-600/40">Сегодня выполнено ✔</span>'


### PR DESCRIPTION
## Summary
- track weekly completion counts for all daily tasks and generic dailies
- apply 5x penalty for missing required weekly repetitions
- show weekly remaining counts in UI

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bea5aa13188327b62c2b9362480026